### PR TITLE
Rename doxx to mr-doc and update options

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"test": "grunt test"
 	},
 	"dependencies": {
-		"doxx": "*",
+		"mr-doc": "*",
 		"rimraf": "2.x"
 	},
 	"devDependencies": {
@@ -41,6 +41,7 @@
 	"keywords": [
 		"gruntplugin",
 		"dox",
+	    "mr-doc",
 		"documentation",
 		"docs",
 		"documentor"

--- a/tasks/doxx.js
+++ b/tasks/doxx.js
@@ -8,7 +8,6 @@
  */
 
 var exec = require('child_process').exec,
-	fs = require('fs'),
 	path = require('path'),
 	rimraf = require('rimraf');
 
@@ -27,23 +26,23 @@ module.exports = function(grunt) {
 			_args.push(arg2);
 		};
 
-		var formatter = [pluginPath, 'node_modules', '.bin', 'doxx'].join(path.sep);
+		var formatter = [pluginPath, 'node_modules', '.bin', 'mr-doc'].join(path.sep);
 
 		rimraf.sync(target);
 
 		_args.add('--source', src);
-		_args.add('--target', target);
+		_args.add('--output', target);
 
 		if(_opts.ignore) {
 			_args.add('--ignore', _opts.ignore);
 		}
 
 		if(_opts.title) {
-			_args.add('--title', '"' + _opts.title + '"');
+			_args.add('--name', '"' + _opts.title + '"');
 		}
 
 		if(_opts.target_extension) {
-			_args.add('--target_extension', _opts.target_extension);
+			_args.add('--extension', _opts.target_extension);
 		}
 
 		if(_opts.template) {


### PR DESCRIPTION
Hi! 

Original module **doxx** (https://github.com/FGRibreau/doxx) has been renamed to **mr-doc** (https://github.com/mr-doc/mr-doc) therefore we need to update grunt-doxx.

Changes are in _package.json_ (`doxx -> mr-doc`) and in _tasks/doxx.js_ according to mr-doc documentation some options have been changed (not in _grunt-doxx_ options) :
`title  -> name, target_extention -> extention, target -> output`

Thank you!